### PR TITLE
ci: Add coreutils to docker docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM docker:28.0.4-alpine3.21
 
 RUN apk add \
         bash \
+        coreutils \
         curl \
         go \
         make \


### PR DESCRIPTION
Need coreutils version of /bin/date to get nanosecond resolution ISO3339 nanosecond time.

test with `date --rfc-3339=ns`